### PR TITLE
Fix: Generics typo

### DIFF
--- a/content/tour/generics.article
+++ b/content/tour/generics.article
@@ -10,7 +10,7 @@ As funções Go podem ser escritas para funcionar em vários tipos usando parâm
 
   func Index[T comparable](s []T, x T) int
 
-Esta declaração significa que `s` é um slice de qualquer tipo `T` que cumpre o
+Esta declaração significa que `s` é um slice de qualquer tipo `T` que cumpre a
 restrição interna `comparable`. `x` também é um valor do mesmo tipo.
 
 `comparable` é uma restrição útil que torna possível usar os operadores `==` e `!=` em valores do tipo. Neste exemplo, usamos para comparar um valor para todos os elementos da slice até que uma correspondência seja encontrada. Esta função `Index` funciona para qualquer tipo que suporte comparação.


### PR DESCRIPTION
Change in article from "o" to "a' for the word "restrição"

Fixes: #55 